### PR TITLE
fix: declare missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,10 @@
             }
         }
     },
-    "repository": ,
+    "repository": {
+        "type" : "git",
+        "url" : "https://github.com/Njanderson/resmon.git"
+    },
     "scripts": {
         "vscode:prepublish": "npm run compile",
         "compile": "tsc -p ./",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
+    "dependencies": {
+        "systeminformation": "^3.0.0"
+    },
     "devDependencies": {
         "typescript": "^2.6.1",
         "vscode": "^1.1.6",


### PR DESCRIPTION
Hi again,

i've managed to make it work!

Apparently the `repository` field on `package.json` was empty/missing, making the file was invalid.

According to documentation i've found:
[Using Node.js Modules with Extensions](https://code.visualstudio.com/docs/extensionAPI/patterns-and-principles#_using-nodejs-modules-with-extensions)

The extension dependencies need to be explictly set in the `dependencies` field, otherwise they won't be present and the code wont run.

the extension is now working.

please accept my contribution, and many many thanks for this extension!
I loved the extension.

fixes #1 